### PR TITLE
Fix invalid chars in filename, datetime, check checksums

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"crypto/md5"
+	"crypto/sha1"
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -27,7 +28,7 @@ type HumbleBundleOrder struct {
 	Product     struct {
 		Category    string
 		MachineName string
-		HumanName   string
+		HumanName   string `json:"human_name"`
 	}
 	GameKey  string `json:"gamekey"`
 	UID      string `json:"uid"`
@@ -60,15 +61,6 @@ func main() {
 	if *gameKey == "" {
 		log.Fatal("Missing key")
 	}
-	if *out == "" {
-		pwd, err := os.Getwd()
-		if err != nil {
-			log.Fatal(err)
-		}
-		*out = fmt.Sprintf("%s/books", pwd)
-	}
-	_ = os.MkdirAll(*out, 0777)
-	log.Printf("Saving files into %s", *out)
 	// Build order endpoint URL
 	u, err := url.Parse(baseURL)
 	if err != nil {
@@ -88,6 +80,21 @@ func main() {
 	if err != nil {
 		log.Fatalf("[ERROR] error unmarshaling order", err)
 	}
+	if *out == "" {
+		log.Printf("Human Name: %s", order.Product.HumanName)
+		if order.Product.HumanName == "" {
+			pwd, err := os.Getwd()
+			if err != nil {
+				log.Fatal(err)
+			}
+			*out = fmt.Sprintf("%s/books", pwd)
+		} else {
+			order.Product.HumanName = strings.Replace(order.Product.HumanName, "/", "_", -1)
+			*out = order.Product.HumanName
+		}
+	}
+	_ = os.MkdirAll(*out, 0777)
+	log.Printf("Saving files into %s", *out)
 
 	// Download all files from order
 	var group sync.WaitGroup
@@ -101,7 +108,8 @@ func main() {
 			for x := 0; x < len(download.DownloadTypes); x++ {
 				downloadType := download.DownloadTypes[x]
 				group.Add(1)
-				go func(name, fileType, downloadURL string) {
+				go func(filename, downloadURL string) {
+					filename = strings.Replace(filename, "/", "_", -1)
 					defer group.Done()
 					resp, err := http.Get(downloadURL)
 					if err != nil {
@@ -109,27 +117,68 @@ func main() {
 						return
 					}
 					defer resp.Body.Close()
+
+					book_lastmod := resp.Header.Get("Last-Modified")
+					book_lastmod_time,err := http.ParseTime(book_lastmod)
+					if err != nil {
+						log.Printf("[ERROR] error with Last-Modified header data %x", err)
+						return
+					}
+
+					log.Printf("Last-Modified Header: ~%s~", book_lastmod)
 					log.Printf("Download status: %d - %s", resp.StatusCode, downloadURL)
 					if resp.StatusCode < 200 || resp.StatusCode > 299 {
 						log.Printf("[ERROR] error status code %d", resp.StatusCode)
 						return
 					}
 
-					bookFile, err := os.Create(fmt.Sprintf("%s/%s.%s", *out, name, fileType))
+					bookFile, err := os.Create(fmt.Sprintf("%s/%s", *out, filename))
 					if err != nil {
 						log.Printf("[ERROR] error creating book file %s", err)
 						return
 					}
 					defer bookFile.Close()
 
-					log.Printf("Saving file %s", name)
-					_, err = io.Copy(bookFile, resp.Body)
+					s, err := ioutil.ReadAll(resp.Body)
 					if err != nil {
-						log.Printf("[ERROR] error reading response body %s", err)
+						log.Printf("[ERROR] error reading response body %s into variable s", err)
 						return
 					}
-					log.Printf("Finished saving file %s.%s", name, fileType)
-				}(prod.HumanName, strings.ToLower(strings.TrimPrefix(downloadType.Name, ".")), downloadType.URL.Web)
+					log.Printf("Saving file %s", filename)
+					_, err = bookFile.Write(s)
+					if err != nil {
+						log.Printf("[ERROR] error reading s %s", err)
+						return
+					}
+					log.Printf("Finished saving file %s", filename)
+					os.Chtimes(fmt.Sprintf("%s/%s", *out, filename), book_lastmod_time, book_lastmod_time)
+
+					if downloadType.SHA1 != "" {
+						log.Printf("Checking SHA1 of file %s", filename)
+						hash := sha1.New()
+						hash.Write([]byte(s))
+						bs := hash.Sum(nil)
+						if downloadType.SHA1 != fmt.Sprintf("%x", bs) {
+							log.Printf("[ERROR] SHA1 FAILED for %s -- expected %s but got %x", filename, downloadType.SHA1, bs)
+						} else {
+							log.Printf("SHA1 okay for %s", filename)
+						}
+						log.Printf("Finished checking SHA1 for file %s", filename)
+					}
+					if downloadType.MD5 != "" {
+						log.Printf("Checking MD5 of file %s", filename)
+						hash := md5.New()
+						hash.Write([]byte(s))
+						bs := hash.Sum(nil)
+						if downloadType.MD5 != fmt.Sprintf("%x", bs) {
+							log.Printf("[ERROR] MD5 FAILED for %s -- expected %s but got %x", filename, downloadType.MD5, bs)
+						} else {
+							log.Printf("MD5 okay for %s", filename)
+						}
+						log.Printf("Finished checking MD5 for file %s%s", filename)
+					}
+
+				}(fmt.Sprintf("%s.%s", prod.HumanName, strings.ToLower(strings.TrimPrefix(downloadType.Name, "."))), downloadType.URL.Web)
 			}
 		}
 	}


### PR DESCRIPTION
- adjusted go function to accept full filename, instead of recreating it
  many times

- check sha1 and md5 checksums as collected from json

- json provied human name may include invalid characters for file names,
  replace "/" with "_"

- add default of "bundle name" for the download directory, instead of
  "books" from json order data

- use Last-Modified from http headers for created file's timestamp